### PR TITLE
Fix stats panel keypress detection

### DIFF
--- a/EStatsPanel.cs
+++ b/EStatsPanel.cs
@@ -371,9 +371,11 @@ namespace EManagersLib {
             if (EKeyBinding.m_toggleStatsPanel.IsPressed(Event.current)) {
                 if (isVisible) {
                     CancelInvoke("RefreshLimit");
+                    Event.current.Use();
                     Hide();
                 } else {
                     InvokeRepeating("RefreshLimit", 0.2f, 4f);
+                    Event.current.Use();
                     Show();
                 }
             }


### PR DESCRIPTION
Fixes issue where keypress to toggle panel visibility can seemingly be ignored due to repeated show/hide retriggering by same keypress.